### PR TITLE
🔧 Auto-fix: Bug: muteVowels crashes when input contains numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * @returns The processed string with vowels replaced.
  * @throws {Error} If mask is not a non-empty string.
  */
-export function muteVowels(input: string, mask: string): string {
+export function muteVowels(input: string, mask: string = '*'): string {
   if (typeof input !== 'string') {
     throw new Error('Input must be a string');
   }


### PR DESCRIPTION
## Auto-generated fix for #11

**Issue:** Bug: muteVowels crashes when input contains numbers
**Description:** When calling muteVowels("abc123"), the function throws an error.

Expected: "*bc123" (only vowels replaced)
Actual: crashes or incorrect output

Steps to reproduce:
1. Import muteVowels
2. Call muteVowels("abc123")
3. Observe error

---

This fix was automatically generated by AutoForge's CommunityAgent.
Please review the changes before merging.

Closes #11